### PR TITLE
[fix] PinRequest struct

### DIFF
--- a/models/view/pin.go
+++ b/models/view/pin.go
@@ -24,7 +24,7 @@ type PinRequest struct {
 	UserID         string    `json:"user_id"`
 	OriginalUserID string    `json:"original_user_id"`
 	ImageURL       string    `json:"image_url"`
-	Title          string    `json:"json"`
+	Title          string    `json:"title"`
 	BoardID        uuid.UUID `json:"board_id"`
 	Description    string    `json:"description"`
 }


### PR DESCRIPTION
PinRequest 構造体の title のタグを `json`→`title`に修正

close #23 